### PR TITLE
Update default port

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 let request = require('request-promise-native'),
     PROTO = 'https://',
-    PORT = 9000;
+    PORT = 7345;
 
 let sendRequest = (method, url, authKey, data) => {
     let req = {


### PR DESCRIPTION
Starting with v4.0.23.2 the default port is now 7345.

Closes https://github.com/heathbar/vizio-smart-cast/issues/9