### PR TITLE
Expand functionality for setting picture mode, sleep timer, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ tv.power.currentMode().then((data) => {
     console.log(data);
 });
 // example output:
-// {"STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"}, "ITEMS": [{"CNAME": "power_mode", "TYPE": "T_VALUE_V1", "NAME": "Power Mode", "VALUE": 0}], "URI": "/state/device/power_mode"}
+// {'STATUS': {'RESULT': 'SUCCESS', 'DETAIL': 'Success'}, 'ITEMS': [{'CNAME': 'power_mode', 'TYPE': 'T_VALUE_V1', 'NAME': 'Power Mode', 'VALUE': 0}], 'URI': '/state/device/power_mode'}
 ```
 
 ## Installation
@@ -40,7 +40,7 @@ _(`void`)_: nothing important
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
+let smartcast = require('vizio-smart-cast');
 smartcast.discover(device => {
   console.log(device);
 });
@@ -70,8 +70,8 @@ _(`smartcast`)_: A new smartcast instance
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101');
 ```
 
 ### `power.currentMode()`
@@ -85,14 +85,14 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101');
 
 tv.power.currentMode().then(data => {
   console.log(data);
 });
 // example output:
-// {"STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"}, "ITEMS": [{"CNAME": "power_mode", "TYPE": "T_VALUE_V1", "NAME": "Power Mode", "VALUE": 0}], "URI": "/state/device/power_mode"}
+// {'STATUS': {'RESULT': 'SUCCESS', 'DETAIL': 'Success'}, 'ITEMS': [{'CNAME': 'power_mode', 'TYPE': 'T_VALUE_V1', 'NAME': 'Power Mode', 'VALUE': 0}], 'URI': '/state/device/power_mode'}
 ```
 
 ### `pairing.initiate([deviceName, [deviceId]])`
@@ -127,9 +127,9 @@ _(`Promise`)_: A promise containing the response from the smartcast device, incl
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let readline = require("readline"); // user input via cmd line
-let tv = new smartcast("192.168.0.101");
+let smartcast = require('vizio-smart-cast');
+let readline = require('readline'); // user input via cmd line
+let tv = new smartcast('192.168.0.101');
 
 // configure cmd line input
 const rl = readline.createInterface({
@@ -140,7 +140,7 @@ const rl = readline.createInterface({
 // Initiate a pairing request with a smartcast device
 tv.pairing.initiate().then(response => {
   // prompt the user for the pin that is displayed on the smartcast device
-  rl.question("Enter PIN:", answer => {
+  rl.question('Enter PIN:', answer => {
     // send the pin to the smartcast device to complete the pairing process
     tv.pairing.pair(answer).then(response => {
       // log the token to be used for future, authenticated requests
@@ -169,14 +169,14 @@ _(`void`)_: Nothing
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101');
 
-tv.pairing.useAuthToken("xAuthTokenx");
+tv.pairing.useAuthToken('xAuthTokenx');
 
 // make a call to an authenticated method
 tv.input.current().then(data => {
-  console.log("response: ", data);
+  console.log('response: ', data);
 });
 ```
 
@@ -191,12 +191,12 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 // make a call to an authenticated method
 tv.input.current().then(data => {
-  console.log("response: ", data);
+  console.log('response: ', data);
 });
 // Example output
 // { STATUS: { RESULT: 'SUCCESS', DETAIL: 'Success' },
@@ -223,107 +223,107 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 // make a call to an authenticated method
 tv.input.list().then(data => {
-  console.log("response: ", data);
+  console.log('response: ', data);
 });
 // Example output
 // {
-//     "STATUS": {
-//         "RESULT": "SUCCESS",
-//         "DETAIL": "Success"
+//     'STATUS': {
+//         'RESULT': 'SUCCESS',
+//         'DETAIL': 'Success'
 //     },
-//     "HASHLIST": [
+//     'HASHLIST': [
 //         1234567890,
 //         0987654321,
 //         9999999999
 //     ],
-//     "GROUP": "G_DEVICES",
-//     "NAME": "Name Input",
-//     "PARAMETERS": {
-//         "FLAT": "TRUE",
-//         "HELPTEXT": "FALSE",
-//         "HASHONLY": "FALSE"
+//     'GROUP': 'G_DEVICES',
+//     'NAME': 'Name Input',
+//     'PARAMETERS': {
+//         'FLAT': 'TRUE',
+//         'HELPTEXT': 'FALSE',
+//         'HASHONLY': 'FALSE'
 //     },
-//     "ITEMS": [
+//     'ITEMS': [
 //         {
-//         "HASHVAL": 1111111111,
-//         "CNAME": "cast",
-//         "NAME": "CAST",
-//         "TYPE": "T_DEVICE_V1",
-//         "READONLY": "TRUE",
-//         "VALUE": {
-//             "NAME": "CAST",
-//             "METADATA": ""
+//         'HASHVAL': 1111111111,
+//         'CNAME': 'cast',
+//         'NAME': 'CAST',
+//         'TYPE': 'T_DEVICE_V1',
+//         'READONLY': 'TRUE',
+//         'VALUE': {
+//             'NAME': 'CAST',
+//             'METADATA': ''
 //         }
 //         },
 //         {
-//         "HASHVAL": 2222222222,
-//         "CNAME": "hdmi1",
-//         "TYPE": "T_DEVICE_V1",
-//         "NAME": "HDMI-1",
-//         "VALUE": {
-//             "NAME": "BLU-RAY",
-//             "METADATA": ""
+//         'HASHVAL': 2222222222,
+//         'CNAME': 'hdmi1',
+//         'TYPE': 'T_DEVICE_V1',
+//         'NAME': 'HDMI-1',
+//         'VALUE': {
+//             'NAME': 'BLU-RAY',
+//             'METADATA': ''
 //         }
 //         },
 //         {
-//         "HASHVAL": 3333333333,
-//         "CNAME": "hdmi2",
-//         "TYPE": "T_DEVICE_V1",
-//         "NAME": "HDMI-2",
-//         "VALUE": {
-//             "NAME": "XBOX 360",
-//             "METADATA": ""
+//         'HASHVAL': 3333333333,
+//         'CNAME': 'hdmi2',
+//         'TYPE': 'T_DEVICE_V1',
+//         'NAME': 'HDMI-2',
+//         'VALUE': {
+//             'NAME': 'XBOX 360',
+//             'METADATA': ''
 //         }
 //         },
 //         {
-//         "HASHVAL": 4444444444,
-//         "CNAME": "hdmi3",
-//         "TYPE": "T_DEVICE_V1",
-//         "NAME": "HDMI-3",
-//         "VALUE": {
-//             "NAME": "XBOX ONE",
-//             "METADATA": ""
+//         'HASHVAL': 4444444444,
+//         'CNAME': 'hdmi3',
+//         'TYPE': 'T_DEVICE_V1',
+//         'NAME': 'HDMI-3',
+//         'VALUE': {
+//             'NAME': 'XBOX ONE',
+//             'METADATA': ''
 //         }
 //         },
 //         {
-//         "HASHVAL": 5555555555,
-//         "CNAME": "hdmi4",
-//         "TYPE": "T_DEVICE_V1",
-//         "NAME": "HDMI-4",
-//         "VALUE": {
-//             "NAME": "PLAYSTATION",
-//             "METADATA": ""
+//         'HASHVAL': 5555555555,
+//         'CNAME': 'hdmi4',
+//         'TYPE': 'T_DEVICE_V1',
+//         'NAME': 'HDMI-4',
+//         'VALUE': {
+//             'NAME': 'PLAYSTATION',
+//             'METADATA': ''
 //         }
 //         },
 //         {
-//         "HASHVAL": 66666666666,
-//         "CNAME": "hdmi5",
-//         "TYPE": "T_DEVICE_V1",
-//         "NAME": "HDMI-5",
-//         "VALUE": {
-//             "NAME": "",
-//             "METADATA": ""
+//         'HASHVAL': 66666666666,
+//         'CNAME': 'hdmi5',
+//         'TYPE': 'T_DEVICE_V1',
+//         'NAME': 'HDMI-5',
+//         'VALUE': {
+//             'NAME': '',
+//             'METADATA': ''
 //         }
 //         },
 //         {
-//         "HASHVAL": 7777777777,
-//         "CNAME": "comp",
-//         "TYPE": "T_DEVICE_V1",
-//         "NAME": "COMP",
-//         "VALUE": {
-//             "NAME": "",
-//             "METADATA": ""
+//         'HASHVAL': 7777777777,
+//         'CNAME': 'comp',
+//         'TYPE': 'T_DEVICE_V1',
+//         'NAME': 'COMP',
+//         'VALUE': {
+//             'NAME': '',
+//             'METADATA': ''
 //         }
 //         }
 //     ],
-//     "URI": "/menu_native/dynamic/tv_settings/devices/name_input",
-//     "CNAME": "name_input",
-//     "TYPE": "T_MENU_V1"
+//     'URI': '/menu_native/dynamic/tv_settings/devices/name_input',
+//     'CNAME': 'name_input',
+//     'TYPE': 'T_MENU_V1'
 // };
 ```
 
@@ -340,14 +340,14 @@ _NOTE:_ the HTTP call may return, and thus the promise may resolve before the sm
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 // Built in names
-tv.input.set("HDMI-1");
+tv.input.set('HDMI-1');
 
 // User defined names
-tv.input.set("Kodi");
+tv.input.set('Kodi');
 ```
 
 ### `control.volume.down()`
@@ -361,8 +361,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.volume.down();
 ```
@@ -378,8 +378,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.volume.up();
 ```
@@ -399,8 +399,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.volume.set(20);
 ```
@@ -416,8 +416,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.volume.mute();
 ```
@@ -433,8 +433,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.volume.unmute();
 ```
@@ -450,8 +450,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.volume.toggleMute();
 ```
@@ -467,8 +467,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.input.cycle();
 ```
@@ -484,8 +484,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.channel.down();
 ```
@@ -501,8 +501,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.channel.up();
 ```
@@ -518,8 +518,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.channel.previous();
 ```
@@ -536,8 +536,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.power.on();
 ```
@@ -553,8 +553,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.power.off();
 ```
@@ -571,8 +571,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.power.toggle();
 ```
@@ -588,8 +588,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.media.seek.forward();
 ```
@@ -605,8 +605,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.media.seek.back();
 ```
@@ -623,8 +623,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.media.play();
 ```
@@ -641,8 +641,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.media.pause();
 ```
@@ -660,8 +660,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.media.cc();
 ```
@@ -677,8 +677,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.navigate.up();
 ```
@@ -694,8 +694,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.navigate.down();
 ```
@@ -711,8 +711,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.navigate.left();
 ```
@@ -728,8 +728,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.navigate.right();
 ```
@@ -745,8 +745,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.navigate.ok();
 ```
@@ -762,8 +762,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.navigate.back();
 ```
@@ -779,8 +779,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.navigate.exit();
 ```
@@ -796,8 +796,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.menu();
 ```
@@ -813,8 +813,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.info();
 ```
@@ -830,8 +830,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.control.smartcast();
 ```
@@ -853,10 +853,10 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
-tv.control.keyCommand(5, 1, "KEYDOWN");
+tv.control.keyCommand(5, 1, 'KEYDOWN');
 ```
 
 ### `settings.picture.get()`
@@ -870,8 +870,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.picture.get().then(data => console.log(data));
 ```
@@ -887,8 +887,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.picture.size.get().then(data => console.log(data));
 ```
@@ -904,8 +904,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.picture.position.get().then(data => console.log(data));
 ```
@@ -921,8 +921,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.picture.modeEdit.get().then(data => console.log(data));
 ```
@@ -938,8 +938,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.picture.mode.get().then(data => console.log(data));
 ```
@@ -955,10 +955,10 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
-tv.settings.picture.mode.set("Standard").then(data => console.log(data));
+tv.settings.picture.mode.set('Standard').then(data => console.log(data));
 ```
 
 ### `settings.picture.color.calibration.get()`
@@ -972,8 +972,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.picture.color.calibration.get().then(data => console.log(data));
 ```
@@ -989,8 +989,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.picture.color.tuner.get().then(data => console.log(data));
 ```
@@ -1006,8 +1006,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.picture.calibrationTests.get().then(data => console.log(data));
 ```
@@ -1023,8 +1023,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.audio.get().then(data => console.log(data));
 ```
@@ -1040,8 +1040,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.timers.get().then(data => console.log(data));
 ```
@@ -1057,8 +1057,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.timers.sleepTimer.get().then(data => console.log(data));
 ```
@@ -1073,12 +1073,12 @@ Sets sleep timer
 
 | Integer | String          | Action                |
 | ------- | --------------- | --------------------- |
-| `0`     | `"Off"`         | turns off sleep timer |
-| `1`     | `"30 minutes"`  | 30 minutes            |
-| `2`     | `"60 minutes"`  | 60 minutes            |
-| `3`     | `"90 minutes"`  | 90 minutes            |
-| `4`     | `"120 minutes"` | 120 minutes           |
-| `5`     | `"180 minutes"` | 180 minutes           |
+| `0`     | `'Off'`         | turns off sleep timer |
+| `1`     | `'30 minutes'`  | 30 minutes            |
+| `2`     | `'60 minutes'`  | 60 minutes            |
+| `3`     | `'90 minutes'`  | 90 minutes            |
+| `4`     | `'120 minutes'` | 120 minutes           |
+| `5`     | `'180 minutes'` | 180 minutes           |
 
 #### Returns
 
@@ -1087,8 +1087,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 // Set the sleep timer to 30 minutes
 tv.settings.timers.sleepTimer.set(1).then(data => console.log(data));
@@ -1105,15 +1105,15 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.timers.autoPowerOffTimer.get().then(data => console.log(data));
 ```
 
 ### `settings.timers.autoPowerOffTimer.set(value)`
 
-Sets auto power off timer setting. By default, it is set to 10 minutes. It can be disabled by setting to "Off".
+Sets auto power off timer setting. By default, it is set to 10 minutes. It can be disabled by setting to 'Off'.
 
 #### Accepts
 
@@ -1121,8 +1121,8 @@ Sets auto power off timer setting. By default, it is set to 10 minutes. It can b
 
 | Integer | String         | Action                            |
 | ------- | -------------- | --------------------------------- |
-| `0`     | `"10 minutes"` | Default auto power off of 10 mins |
-| `1`     | `"Off"`        | Disable this feature              |
+| `0`     | `'10 minutes'` | Default auto power off of 10 mins |
+| `1`     | `'Off'`        | Disable this feature              |
 
 #### Returns
 
@@ -1131,8 +1131,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 // Disable auto power off timer
 tv.settings.timers.autoPowerOffTimer.set(1).then(data => console.log(data));
@@ -1150,8 +1150,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.timers.blankScreen.get().then(data => console.log(data));
 ```
@@ -1167,8 +1167,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 // Turn off the screen only
 tv.settings.timers.blankScreen.execute().then(data => console.log(data));
@@ -1185,8 +1185,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.network.get().then(data => console.log(data));
 ```
@@ -1202,8 +1202,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.channels.get().then(data => console.log(data));
 ```
@@ -1219,8 +1219,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.closedCaptions.get().then(data => console.log(data));
 ```
@@ -1236,8 +1236,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.devices.get().then(data => console.log(data));
 ```
@@ -1253,8 +1253,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.system.get().then(data => console.log(data));
 ```
@@ -1270,8 +1270,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.system.information.get().then(data => console.log(data));
 ```
@@ -1287,8 +1287,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.system.information.tv.get().then(data => console.log(data));
 ```
@@ -1304,8 +1304,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.system.information.tuner.get().then(data => console.log(data));
 ```
@@ -1321,8 +1321,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.system.information.network.get().then(data => console.log(data));
 ```
@@ -1338,8 +1338,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.system.information.uli.get().then(data => console.log(data));
 ```
@@ -1355,8 +1355,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.mobileDevices.get().then(data => console.log(data));
 ```
@@ -1372,8 +1372,8 @@ _(`Promise`)_: A promise of the http response from the smartcast device
 #### Example
 
 ```js
-let smartcast = require("vizio-smart-cast");
-let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+let smartcast = require('vizio-smart-cast');
+let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
 tv.settings.cast.get().then(data => console.log(data));
 ```

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ tv.pairing.initiate().then(response => {
 
 Skip the pairing process and use the specified token instead. On first run, a call to `pairing.pair(...)` is required to obtain an auth token. On successive runs, use this method to skip the pairing process.
 
-_NOTE:_ the authorization token can also be specified in the constructor. Either way, the libarary remembers it for the remainder of the smartcast instance.
+*NOTE:* the authorization token can also be specified in the constructor. Either way, the libarary remembers it for the remainder of the smartcast instance.
 
 #### Arguments
 
@@ -335,7 +335,7 @@ Set the current input to the specified name. Name can be either the built-in nam
 
 *(`Promise`)*: A promise of the http response from the smartcast device
 
-_NOTE:_ the HTTP call may return, and thus the promise may resolve before the smartcast device has finished changing inputs. For that reason, it is possible to receive the old value from tv.input.current() if you call it immediately after the promise from tv.input.set(...) resolves.
+*NOTE:* the HTTP call may return, and thus the promise may resolve before the smartcast device has finished changing inputs. For that reason, it is possible to receive the old value from tv.input.current() if you call it immediately after the promise from tv.input.set(...) resolves.
 
 #### Example
 
@@ -527,7 +527,7 @@ tv.control.channel.previous();
 ### `control.power.on()`
 
 Turn on the device.
-_Note:_ some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
+*NOTE:* some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
 
 #### Returns
 
@@ -562,7 +562,7 @@ tv.control.power.off();
 ### `control.power.toggle()`
 
 Toggle power to the device.
-_Note:_ some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
+*NOTE:* some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
 
 #### Returns
 
@@ -614,7 +614,7 @@ tv.control.media.seek.back();
 ### `control.media.play()`
 
 Plays the current media
-_Note:_ Some applications will toggle play / pause
+*NOTE:* Some applications will toggle play / pause
 
 #### Returns
 
@@ -632,7 +632,7 @@ tv.control.media.play();
 ### `control.media.pause()`
 
 Pauses the current media
-_Note:_ Some applications will toggle play / pause
+*NOTE:* Some applications will toggle play / pause
 
 #### Returns
 
@@ -650,7 +650,7 @@ tv.control.media.pause();
 ### `control.media.cc()`
 
 Sends closed captioning key
-_Note:_ Some applications require sending this command to switch between languages
+*NOTE:* Some applications require sending this command to switch between languages
 The arrow keys should also work for this.
 
 #### Returns

--- a/README.md
+++ b/README.md
@@ -1067,11 +1067,13 @@ tv.settings.timers.sleepTimer.get().then(data => console.log(data));
 
 Sets sleep timer
 
-#### Accepts
+#### Arguments
+
+1. `value` *(string|number)*: The value of the sleep timer as a string value or the numbered index.
 
 > NOTE: library will not allow you to set value outside of these parameters to prevent potentially bricking your display.
 
-| Integer | String          | Action                |
+| Number  | String          | Action                |
 | ------- | --------------- | --------------------- |
 | `0`     | `'Off'`         | turns off sleep timer |
 | `1`     | `'30 minutes'`  | 30 minutes            |
@@ -1115,7 +1117,9 @@ tv.settings.timers.autoPowerOffTimer.get().then(data => console.log(data));
 
 Sets auto power off timer setting. By default, it is set to 10 minutes. It can be disabled by setting to 'Off'.
 
-#### Accepts
+#### Arguments
+
+1. `value` *(number|string)*: The value of the autoPowerOffTimer setting as the string value or the numbered index.
 
 > NOTE: library will not allow you to set value outside of these parameters to prevent potentially bricking your display.
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Discover smartcast devices on the local network
 
 #### Arguments
 
-1. `success` _(Function)_: callback to execute when a device is found
-1. `error` _(Function)_: callback to execute when an error occurs
-1. `timeout` _(number)_: number of milliseconds to wait for responses, defaults to 4000ms
+1. `success` *(Function)*: callback to execute when a device is found
+1. `error` *(Function)*: callback to execute when an error occurs
+1. `timeout` *(number)*: number of milliseconds to wait for responses, defaults to 4000ms
 
 #### Returns
 
-_(`void`)_: nothing important
+*(`void`)*: nothing important
 
 #### Example
 
@@ -60,12 +60,12 @@ Instatiates a new smartcast device
 
 #### Arguments
 
-1. `host` _(string)_: Host IP address (and optionally PORT) of the smartcast device
-1. `[authToken]` _(string)_: Authorization token from a previous session. Auth tokens are returned from `pairing.pair(...)`
+1. `host` *(string)*: Host IP address (and optionally PORT) of the smartcast device
+1. `[authToken]` *(string)*: Authorization token from a previous session. Auth tokens are returned from `pairing.pair(...)`
 
 #### Returns
 
-_(`smartcast`)_: A new smartcast instance
+*(`smartcast`)*: A new smartcast instance
 
 #### Example
 
@@ -80,7 +80,7 @@ Fetch current tv power mode.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -101,12 +101,12 @@ Initiate pairing with a smartcast device. If successful, a pin will be displayed
 
 #### Arguments
 
-1. `[deviceName]` _(string='node-app-1234567890')_: Name of the connecting device/app
-1. `[deviceId]` _(string='node-app-1234567890')_: ID of the connecting device/app
+1. `[deviceName]` *(string='node-app-1234567890')*: Name of the connecting device/app
+1. `[deviceId]` *(string='node-app-1234567890')*: ID of the connecting device/app
 
 #### Returns
 
-_(`Promise`)_: A promise containing the response from the smartcast device
+*(`Promise`)*: A promise containing the response from the smartcast device
 
 #### Example
 
@@ -118,11 +118,11 @@ Provide a user-entered pin to the smartcast device. The smartcast device will re
 
 #### Arguments
 
-1. `pin` _(string)_: The pin displayed on the smartcast device after a successful `pairing.initiate()` call
+1. `pin` *(string)*: The pin displayed on the smartcast device after a successful `pairing.initiate()` call
 
 #### Returns
 
-_(`Promise`)_: A promise containing the response from the smartcast device, including the auth token to use for future requests
+*(`Promise`)*: A promise containing the response from the smartcast device, including the auth token to use for future requests
 
 #### Example
 
@@ -160,11 +160,11 @@ _NOTE:_ the authorization token can also be specified in the constructor. Either
 
 #### Arguments
 
-1. `token` _(string)_: The token retrieved from a successful `pairing.pair(...)` call
+1. `token` *(string)*: The token retrieved from a successful `pairing.pair(...)` call
 
 #### Returns
 
-_(`void`)_: Nothing
+*(`void`)*: Nothing
 
 #### Example
 
@@ -186,7 +186,7 @@ Fetch current tv input.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -218,7 +218,7 @@ Fetch the list of all inputs
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -333,7 +333,7 @@ Set the current input to the specified name. Name can be either the built-in nam
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 _NOTE:_ the HTTP call may return, and thus the promise may resolve before the smartcast device has finished changing inputs. For that reason, it is possible to receive the old value from tv.input.current() if you call it immediately after the promise from tv.input.set(...) resolves.
 
@@ -356,7 +356,7 @@ Turn volume down one step
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -373,7 +373,7 @@ Turn volume up one step
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -390,11 +390,11 @@ Specify a specific volume level
 
 #### Arguments
 
-1. `value` _(number)_: The volume level to set [0-100]
+1. `value` *(number)*: The volume level to set [0-100]
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -411,7 +411,7 @@ Mute the volume
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -428,7 +428,7 @@ Unmute the volume
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -445,7 +445,7 @@ Toggle muting of the volume
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -462,7 +462,7 @@ Select the next input
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -479,7 +479,7 @@ Move down one channel
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -496,7 +496,7 @@ Move up one channel
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -513,7 +513,7 @@ Move to the previous channel
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -531,7 +531,7 @@ _Note:_ some devices may require you to send a WOL magic packet to first wake-up
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -548,7 +548,7 @@ Turn off the device
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -566,7 +566,7 @@ _Note:_ some devices may require you to send a WOL magic packet to first wake-up
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -583,7 +583,7 @@ Seeks the current media forward
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -600,7 +600,7 @@ Seeks the current media backwards
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -618,7 +618,7 @@ _Note:_ Some applications will toggle play / pause
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -636,7 +636,7 @@ _Note:_ Some applications will toggle play / pause
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -655,7 +655,7 @@ The arrow keys should also work for this.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -672,7 +672,7 @@ Up arrow key used to navigate.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -689,7 +689,7 @@ Down arrow key used to navigate.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -706,7 +706,7 @@ Left arrow key used to navigate.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -723,7 +723,7 @@ Right arrow key used to navigate.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -740,7 +740,7 @@ Ok key used for navigating.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -757,7 +757,7 @@ Navigate back in an application.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -774,7 +774,7 @@ Exit an application.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -791,7 +791,7 @@ Launch the on-screen menu.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -808,7 +808,7 @@ Displays the tuner information.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -825,7 +825,7 @@ Launch the smartcast application.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -842,13 +842,13 @@ Send a key command to the smartcast device.
 
 #### Arguments
 
-1. `codeset` _(number)_: The codeset to send. See https://github.com/exiva/Vizio_SmartCast_API
-1. `code` _(number)_: The code to send. See https://github.com/exiva/Vizio_SmartCast_API
-1. `[action]` _(string=KEYPRESS)_: The action to send. One of: `KEYDOWN`, `KEYUP`, `KEYPRESS`.
+1. `codeset` *(number)*: The codeset to send. See https://github.com/exiva/Vizio_SmartCast_API
+1. `code` *(number)*: The code to send. See https://github.com/exiva/Vizio_SmartCast_API
+1. `[action]` *(string=KEYPRESS)*: The action to send. One of: `KEYDOWN`, `KEYUP`, `KEYPRESS`.
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -865,7 +865,7 @@ Get picture settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -882,7 +882,7 @@ Get picture size settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -899,7 +899,7 @@ Get picture position settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -916,7 +916,7 @@ Get mode settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -933,7 +933,7 @@ Get picture mode
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -950,7 +950,7 @@ Set picture mode
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -967,7 +967,7 @@ Get color calibration settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -984,7 +984,7 @@ Get color tuner settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1001,7 +1001,7 @@ Get calibration test settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1018,7 +1018,7 @@ Get audio settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1035,7 +1035,7 @@ Get timer settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1052,7 +1052,7 @@ Get sleep timer settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1082,7 +1082,7 @@ Sets sleep timer
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1100,7 +1100,7 @@ Get auto power off timer settings. With no video input (DVD player falls asleep)
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1126,7 +1126,7 @@ Sets auto power off timer setting. By default, it is set to 10 minutes. It can b
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1145,7 +1145,7 @@ used internally to trigger the action. See `execute()` below to perform the acti
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1162,7 +1162,7 @@ Executes the blank screen action to turn off the display but continue playing th
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1180,7 +1180,7 @@ Get network settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1197,7 +1197,7 @@ Get channels settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1214,7 +1214,7 @@ Get closed caption settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1231,7 +1231,7 @@ Get devices settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1248,7 +1248,7 @@ Get system settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1265,7 +1265,7 @@ Get system information settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1282,7 +1282,7 @@ Get tv information
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1299,7 +1299,7 @@ Get tuner information
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1316,7 +1316,7 @@ Get network information
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1333,7 +1333,7 @@ Get ULI information
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1350,7 +1350,7 @@ Get mobile device settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 
@@ -1367,7 +1367,7 @@ Get cast settings
 
 #### Returns
 
-_(`Promise`)_: A promise of the http response from the smartcast device
+*(`Promise`)*: A promise of the http response from the smartcast device
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -24,21 +24,25 @@ npm install vizio-smart-cast --save
 ## API Reference
 
 ### `smartcast.discover(success, [error, [timeout]] )`
+
 Discover smartcast devices on the local network
 
 #### Arguments
-1. `success` *(Function)*: callback to execute when a device is found
-1. `error` *(Function)*: callback to execute when an error occurs
-1. `timeout` *(number)*: number of milliseconds to wait for responses, defaults to 4000ms
+
+1. `success` _(Function)_: callback to execute when a device is found
+1. `error` _(Function)_: callback to execute when an error occurs
+1. `timeout` _(number)_: number of milliseconds to wait for responses, defaults to 4000ms
 
 #### Returns
-*(`void`)*: nothing important
+
+_(`void`)_: nothing important
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-smartcast.discover((device) => {
-    console.log(device);
+let smartcast = require("vizio-smart-cast");
+smartcast.discover(device => {
+  console.log(device);
 });
 
 // Example output:
@@ -51,130 +55,148 @@ smartcast.discover((device) => {
 ```
 
 ### `new smartcast(host, [authToken])`
+
 Instatiates a new smartcast device
 
 #### Arguments
-1. `host` *(string)*: Host IP address (and optionally PORT) of the smartcast device
-1. `[authToken]` *(string)*: Authorization token from a previous session. Auth tokens are returned from `pairing.pair(...)`
+
+1. `host` _(string)_: Host IP address (and optionally PORT) of the smartcast device
+1. `[authToken]` _(string)_: Authorization token from a previous session. Auth tokens are returned from `pairing.pair(...)`
 
 #### Returns
-*(`smartcast`)*: A new smartcast instance
+
+_(`smartcast`)_: A new smartcast instance
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101");
 ```
 
 ### `power.currentMode()`
+
 Fetch current tv power mode.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
-```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101');
 
-tv.power.currentMode().then((data) => {
-    console.log(data);
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101");
+
+tv.power.currentMode().then(data => {
+  console.log(data);
 });
 // example output:
 // {"STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"}, "ITEMS": [{"CNAME": "power_mode", "TYPE": "T_VALUE_V1", "NAME": "Power Mode", "VALUE": 0}], "URI": "/state/device/power_mode"}
 ```
 
 ### `pairing.initiate([deviceName, [deviceId]])`
+
 Initiate pairing with a smartcast device. If successful, a pin will be displayed on the screen of the smartcast device. Device name and ID appear in the SmartCast app to uniquely identify and manage connections.
 
 #### Arguments
-1. `[deviceName]` *(string='node-app-1234567890')*: Name of the connecting device/app
-1. `[deviceId]` *(string='node-app-1234567890')*: ID of the connecting device/app
+
+1. `[deviceName]` _(string='node-app-1234567890')_: Name of the connecting device/app
+1. `[deviceId]` _(string='node-app-1234567890')_: ID of the connecting device/app
 
 #### Returns
-*(`Promise`)*: A promise containing the response from the smartcast device
+
+_(`Promise`)_: A promise containing the response from the smartcast device
 
 #### Example
+
 see next method for example
 
 ### `pairing.pair(pin)`
+
 Provide a user-entered pin to the smartcast device. The smartcast device will respond with an auth token that can be used indefinitely. The vizio-smart-cast library will automatically re-use the token for the remainder of the session. For future sessions, specify the authToken in the constructor or call `pairing.useAuthToken(...)` with the token to skip the pairing process.
 
 #### Arguments
-1. `pin` *(string)*: The pin displayed on the smartcast device after a successful `pairing.initiate()` call
+
+1. `pin` _(string)_: The pin displayed on the smartcast device after a successful `pairing.initiate()` call
 
 #### Returns
-*(`Promise`)*: A promise containing the response from the smartcast device, including the auth token to use for future requests
+
+_(`Promise`)_: A promise containing the response from the smartcast device, including the auth token to use for future requests
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let readline = require('readline'); // user input via cmd line
-let tv = new smartcast('192.168.0.101');
+let smartcast = require("vizio-smart-cast");
+let readline = require("readline"); // user input via cmd line
+let tv = new smartcast("192.168.0.101");
 
 // configure cmd line input
 const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
+  input: process.stdin,
+  output: process.stdout
 });
 
 // Initiate a pairing request with a smartcast device
-tv.pairing.initiate().then((response) => {
-
-    // prompt the user for the pin that is displayed on the smartcast device
-    rl.question('Enter PIN:', (answer) => {
-
-        // send the pin to the smartcast device to complete the pairing process
-        tv.pairing.pair(answer).then((response) => {
-
-            // log the token to be used for future, authenticated requests
-            console.log(response.ITEM.AUTH_TOKEN);
-        });
-
-        rl.close();
+tv.pairing.initiate().then(response => {
+  // prompt the user for the pin that is displayed on the smartcast device
+  rl.question("Enter PIN:", answer => {
+    // send the pin to the smartcast device to complete the pairing process
+    tv.pairing.pair(answer).then(response => {
+      // log the token to be used for future, authenticated requests
+      console.log(response.ITEM.AUTH_TOKEN);
     });
+
+    rl.close();
+  });
 });
 ```
 
 ### `pairing.useAuthToken(token)`
+
 Skip the pairing process and use the specified token instead. On first run, a call to `pairing.pair(...)` is required to obtain an auth token. On successive runs, use this method to skip the pairing process.
 
-*NOTE:* the authorization token can also be specified in the constructor. Either way, the libarary remembers it for the remainder of the smartcast instance.
+_NOTE:_ the authorization token can also be specified in the constructor. Either way, the libarary remembers it for the remainder of the smartcast instance.
 
 #### Arguments
-1. `token` *(string)*: The token retrieved from a successful `pairing.pair(...)` call
+
+1. `token` _(string)_: The token retrieved from a successful `pairing.pair(...)` call
 
 #### Returns
-*(`void`)*: Nothing
+
+_(`void`)_: Nothing
 
 #### Example
-```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101');
 
-tv.pairing.useAuthToken('xAuthTokenx');
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101");
+
+tv.pairing.useAuthToken("xAuthTokenx");
 
 // make a call to an authenticated method
-tv.input.current().then((data) => {
-    console.log('response: ', data);
+tv.input.current().then(data => {
+  console.log("response: ", data);
 });
-
 ```
 
 ### `input.current()`
+
 Fetch current tv input.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 // make a call to an authenticated method
-tv.input.current().then((data) => {
-    console.log('response: ', data);
+tv.input.current().then(data => {
+  console.log("response: ", data);
 });
 // Example output
 // { STATUS: { RESULT: 'SUCCESS', DETAIL: 'Success' },
@@ -191,22 +213,25 @@ tv.input.current().then((data) => {
 ```
 
 ### `input.list()`
+
 Fetch the list of all inputs
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 // make a call to an authenticated method
-tv.input.list().then((data) => {
-    console.log('response: ', data);
+tv.input.list().then(data => {
+  console.log("response: ", data);
 });
 // Example output
- // {
+// {
 //     "STATUS": {
 //         "RESULT": "SUCCESS",
 //         "DETAIL": "Success"
@@ -303,736 +328,1052 @@ tv.input.list().then((data) => {
 ```
 
 ### `input.set(name)`
+
 Set the current input to the specified name. Name can be either the built-in name or the user defined name and is case insensitive.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
 
-*NOTE:* the HTTP call may return, and thus the promise may resolve before the smartcast device has finished changing inputs. For that reason, it is possible to receive the old value from tv.input.current() if you call it immediately after the promise from tv.input.set(...) resolves.
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+_NOTE:_ the HTTP call may return, and thus the promise may resolve before the smartcast device has finished changing inputs. For that reason, it is possible to receive the old value from tv.input.current() if you call it immediately after the promise from tv.input.set(...) resolves.
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 // Built in names
-tv.input.set('HDMI-1');
+tv.input.set("HDMI-1");
 
 // User defined names
-tv.input.set('Kodi');
+tv.input.set("Kodi");
 ```
 
 ### `control.volume.down()`
+
 Turn volume down one step
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.volume.down();
 ```
 
 ### `control.volume.up()`
+
 Turn volume up one step
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.volume.up();
 ```
+
 ### `control.volume.set(value)`
+
 Specify a specific volume level
 
 #### Arguments
-1. `value` *(number)*: The volume level to set [0-100]
+
+1. `value` _(number)_: The volume level to set [0-100]
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.volume.set(20);
 ```
 
 ### `control.volume.mute()`
+
 Mute the volume
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.volume.mute();
 ```
 
 ### `control.volume.unmute()`
+
 Unmute the volume
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.volume.unmute();
 ```
 
 ### `control.volume.toggleMute()`
+
 Toggle muting of the volume
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.volume.toggleMute();
 ```
 
 ### `control.input.cycle()`
+
 Select the next input
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.input.cycle();
 ```
 
 ### `control.channel.down()`
+
 Move down one channel
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.channel.down();
 ```
 
 ### `control.channel.up()`
+
 Move up one channel
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.channel.up();
 ```
 
 ### `control.channel.previous()`
+
 Move to the previous channel
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.channel.previous();
 ```
 
 ### `control.power.on()`
+
 Turn on the device.
-*Note:* some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
+_Note:_ some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.power.on();
 ```
 
 ### `control.power.off()`
+
 Turn off the device
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.power.off();
 ```
 
 ### `control.power.toggle()`
+
 Toggle power to the device.
-*Note:* some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
+_Note:_ some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.power.toggle();
 ```
 
 ### `control.media.seek.forward()`
+
 Seeks the current media forward
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.media.seek.forward();
 ```
 
-
 ### `control.media.seek.back()`
+
 Seeks the current media backwards
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.media.seek.back();
 ```
 
 ### `control.media.play()`
+
 Plays the current media
-*Note:* Some applications will toggle play / pause
+_Note:_ Some applications will toggle play / pause
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.media.play();
 ```
 
 ### `control.media.pause()`
+
 Pauses the current media
-*Note:* Some applications will toggle play / pause
+_Note:_ Some applications will toggle play / pause
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.media.pause();
 ```
 
 ### `control.media.cc()`
+
 Sends closed captioning key
-*Note:* Some applications require sending this command to switch between languages
+_Note:_ Some applications require sending this command to switch between languages
 The arrow keys should also work for this.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.media.cc();
 ```
 
 ### `control.navigate.up()`
+
 Up arrow key used to navigate.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.navigate.up();
 ```
 
 ### `control.navigate.down()`
+
 Down arrow key used to navigate.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.navigate.down();
 ```
 
 ### `control.navigate.left()`
+
 Left arrow key used to navigate.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.navigate.left();
 ```
 
 ### `control.navigate.right()`
+
 Right arrow key used to navigate.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.navigate.right();
 ```
 
 ### `control.navigate.ok()`
+
 Ok key used for navigating.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.navigate.ok();
 ```
 
 ### `control.navigate.back()`
+
 Navigate back in an application.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.navigate.back();
 ```
 
 ### `control.navigate.exit()`
+
 Exit an application.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.navigate.exit();
 ```
 
 ### `control.menu()`
+
 Launch the on-screen menu.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.menu();
 ```
 
 ### `control.info()`
+
 Displays the tuner information.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.info();
 ```
 
 ### `control.smartcast()`
+
 Launch the smartcast application.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.control.smartcast();
 ```
 
 ### `control.keyCommand(codeset, code, [action])`
+
 Send a key command to the smartcast device.
 
 #### Arguments
-1. `codeset` *(number)*: The codeset to send. See https://github.com/exiva/Vizio_SmartCast_API
-1. `code` *(number)*: The code to send. See https://github.com/exiva/Vizio_SmartCast_API
-1. `[action]` *(string=KEYPRESS)*: The action to send. One of: `KEYDOWN`, `KEYUP`, `KEYPRESS`.
 
+1. `codeset` _(number)_: The codeset to send. See https://github.com/exiva/Vizio_SmartCast_API
+1. `code` _(number)_: The code to send. See https://github.com/exiva/Vizio_SmartCast_API
+1. `[action]` _(string=KEYPRESS)_: The action to send. One of: `KEYDOWN`, `KEYUP`, `KEYPRESS`.
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
-```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
 
-tv.control.keyCommand(5, 1, 'KEYDOWN');
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+tv.control.keyCommand(5, 1, "KEYDOWN");
 ```
 
 ### `settings.picture.get()`
+
 Get picture settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.picture.get().then(data => console.log(data));
 ```
 
 ### `settings.picture.size.get()`
+
 Get picture size settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.picture.size.get().then(data => console.log(data));
 ```
 
 ### `settings.picture.position.get()`
+
 Get picture position settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.picture.position.get().then(data => console.log(data));
 ```
 
 ### `settings.picture.modeEdit.get()`
+
 Get mode settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.picture.modeEdit.get().then(data => console.log(data));
 ```
 
+### `settings.picture.mode.get()`
+
+Get picture mode
+
+#### Returns
+
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+#### Example
+
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+tv.settings.picture.mode.get().then(data => console.log(data));
+```
+
+### `settings.picture.mode.set(value)`
+
+Set picture mode
+
+#### Returns
+
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+#### Example
+
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+tv.settings.picture.mode.set("Standard").then(data => console.log(data));
+```
+
 ### `settings.picture.color.calibration.get()`
+
 Get color calibration settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.picture.color.calibration.get().then(data => console.log(data));
 ```
 
 ### `settings.picture.color.tuner.get()`
+
 Get color tuner settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.picture.color.tuner.get().then(data => console.log(data));
 ```
 
 ### `settings.picture.calibrationTests.get()`
+
 Get calibration test settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.picture.calibrationTests.get().then(data => console.log(data));
 ```
 
 ### `settings.audio.get()`
+
 Get audio settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.audio.get().then(data => console.log(data));
 ```
 
 ### `settings.timers.get()`
+
 Get timer settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.timers.get().then(data => console.log(data));
 ```
 
+### `settings.timers.sleepTimer.get()`
+
+Get sleep timer settings
+
+#### Returns
+
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+#### Example
+
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+tv.settings.timers.sleepTimer.get().then(data => console.log(data));
+```
+
+### `settings.timers.sleepTimer.set(value)`
+
+Sets sleep timer
+
+#### Accepts
+
+> NOTE: library will not allow you to set value outside of these parameters to prevent potentially bricking your display.
+
+| Integer | String          | Action                |
+| ------- | --------------- | --------------------- |
+| `0`     | `"Off"`         | turns off sleep timer |
+| `1`     | `"30 minutes"`  | 30 minutes            |
+| `2`     | `"60 minutes"`  | 60 minutes            |
+| `3`     | `"90 minutes"`  | 90 minutes            |
+| `4`     | `"120 minutes"` | 120 minutes           |
+| `5`     | `"180 minutes"` | 180 minutes           |
+
+#### Returns
+
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+#### Example
+
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+// Set the sleep timer to 30 minutes
+tv.settings.timers.sleepTimer.set(1).then(data => console.log(data));
+```
+
+### `settings.timers.autoPowerOffTimer.get()`
+
+Get auto power off timer settings. With no video input (DVD player falls asleep), the TV will turn off after 10 minutes.
+
+#### Returns
+
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+#### Example
+
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+tv.settings.timers.autoPowerOffTimer.get().then(data => console.log(data));
+```
+
+### `settings.timers.autoPowerOffTimer.set(value)`
+
+Sets auto power off timer setting. By default, it is set to 10 minutes. It can be disabled by setting to "Off".
+
+#### Accepts
+
+> NOTE: library will not allow you to set value outside of these parameters to prevent potentially bricking your display.
+
+| Integer | String         | Action                            |
+| ------- | -------------- | --------------------------------- |
+| `0`     | `"10 minutes"` | Default auto power off of 10 mins |
+| `1`     | `"Off"`        | Disable this feature              |
+
+#### Returns
+
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+#### Example
+
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+// Disable auto power off timer
+tv.settings.timers.autoPowerOffTimer.set(1).then(data => console.log(data));
+```
+
+### `settings.timers.blankScreen.get()`
+
+Get the blankScreen settings. Due to this being an executable action, and not a list, there is no meaningful value returned by this aside from `hashval`, which is 
+used internally to trigger the action. See `execute()` below to perform the action.
+
+#### Returns
+
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+#### Example
+
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+tv.settings.timers.blankScreen.get().then(data => console.log(data));
+```
+
+### `settings.timers.blankScreen.execute()`
+
+Executes the blank screen action to turn off the display but continue playing the content (audio is still available). 
+
+#### Returns
+
+_(`Promise`)_: A promise of the http response from the smartcast device
+
+#### Example
+
+```js
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
+
+// Turn off the screen only
+tv.settings.timers.blankScreen.execute().then(data => console.log(data));
+```
+
 ### `settings.network.get()`
+
 Get network settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.network.get().then(data => console.log(data));
 ```
 
 ### `settings.channels.get()`
+
 Get channels settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.channels.get().then(data => console.log(data));
 ```
 
 ### `settings.closedCaptions.get()`
+
 Get closed caption settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.closedCaptions.get().then(data => console.log(data));
 ```
 
 ### `settings.devices.get()`
+
 Get devices settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.devices.get().then(data => console.log(data));
 ```
 
 ### `settings.system.get()`
+
 Get system settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.system.get().then(data => console.log(data));
 ```
 
 ### `settings.system.information.get()`
+
 Get system information settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.system.information.get().then(data => console.log(data));
 ```
 
 ### `settings.system.information.tv.get()`
+
 Get tv information
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.system.information.tv.get().then(data => console.log(data));
 ```
 
 ### `settings.system.information.tuner.get()`
+
 Get tuner information
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.system.information.tuner.get().then(data => console.log(data));
 ```
 
 ### `settings.system.information.network.get()`
+
 Get network information
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.system.information.network.get().then(data => console.log(data));
 ```
 
 ### `settings.system.information.uli.get()`
+
 Get ULI information
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.system.information.uli.get().then(data => console.log(data));
 ```
 
 ### `settings.mobileDevices.get()`
+
 Get mobile device settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.mobileDevices.get().then(data => console.log(data));
 ```
 
 ### `settings.cast.get()`
+
 Get cast settings
 
 #### Returns
-*(`Promise`)*: A promise of the http response from the smartcast device
+
+_(`Promise`)_: A promise of the http response from the smartcast device
 
 #### Example
+
 ```js
-let smartcast = require('vizio-smart-cast');
-let tv = new smartcast('192.168.0.101', 'xAuthTokenx');
+let smartcast = require("vizio-smart-cast");
+let tv = new smartcast("192.168.0.101", "xAuthTokenx");
 
 tv.settings.cast.get().then(data => console.log(data));
 ```
@@ -1042,6 +1383,7 @@ tv.settings.cast.get().then(data => console.log(data));
 npm test
 
 ## Contributors
+
 This was all made possible by the reference guide here: https://github.com/exiva/Vizio_SmartCast_API
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1389,5 +1389,4 @@ This was all made possible by the reference guide here: https://github.com/exiva
 ## License
 
 ISC License
-Permission to use, copy, modify, and/or d*Note:* some devices may require you to send a WOL magic packet to first wake-up the device. Eco-mode is not supported.
-istribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ tv.power.currentMode().then((data) => {
     console.log(data);
 });
 // example output:
-// {'STATUS': {'RESULT': 'SUCCESS', 'DETAIL': 'Success'}, 'ITEMS': [{'CNAME': 'power_mode', 'TYPE': 'T_VALUE_V1', 'NAME': 'Power Mode', 'VALUE': 0}], 'URI': '/state/device/power_mode'}
+// {"STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"}, "ITEMS": [{"CNAME": "power_mode", "TYPE": "T_VALUE_V1", "NAME": "Power Mode", "VALUE": 0}], "URI": "/state/device/power_mode"}
 ```
 
 ## Installation
@@ -47,10 +47,10 @@ smartcast.discover(device => {
 
 // Example output:
 // {
-//     ip: '192.168.0.131',
-//     name: 'Living Room',
-//     manufacturer: 'VIZIO',
-//     model: 'P65-C1'
+//     ip: "192.168.0.131",
+//     name: "Living Room",
+//     manufacturer: "VIZIO",
+//     model: "P65-C1"
 // }
 ```
 
@@ -92,7 +92,7 @@ tv.power.currentMode().then(data => {
   console.log(data);
 });
 // example output:
-// {'STATUS': {'RESULT': 'SUCCESS', 'DETAIL': 'Success'}, 'ITEMS': [{'CNAME': 'power_mode', 'TYPE': 'T_VALUE_V1', 'NAME': 'Power Mode', 'VALUE': 0}], 'URI': '/state/device/power_mode'}
+// {"STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"}, "ITEMS": [{"CNAME": "power_mode", "TYPE": "T_VALUE_V1", "NAME": "Power Mode", "VALUE": 0}], "URI": "/state/device/power_mode"}
 ```
 
 ### `pairing.initiate([deviceName, [deviceId]])`
@@ -199,17 +199,17 @@ tv.input.current().then(data => {
   console.log('response: ', data);
 });
 // Example output
-// { STATUS: { RESULT: 'SUCCESS', DETAIL: 'Success' },
+// { STATUS: { RESULT: "SUCCESS", DETAIL: "Success" },
 //  ITEMS:
 //   [ { HASHVAL: 1234123412,
-//       NAME: 'Current Input',
-//       ENABLED: 'FALSE',
-//       VALUE: 'HDMI-1',
-//       CNAME: 'current_input',
-//       TYPE: 'T_STRING_V1' } ],
+//       NAME: "Current Input",
+//       ENABLED: "FALSE",
+//       VALUE: "HDMI-1",
+//       CNAME: "current_input",
+//       TYPE: "T_STRING_V1" } ],
 //  HASHLIST: [ 0928345790, 9087654321 ],
-//  URI: '/menu_native/dynamic/tv_settings/devices/current_input',
-//  PARAMETERS: { FLAT: 'TRUE', HELPTEXT: 'FALSE', HASHONLY: 'FALSE' } }
+//  URI: "/menu_native/dynamic/tv_settings/devices/current_input",
+//  PARAMETERS: { FLAT: "TRUE", HELPTEXT: "FALSE", HASHONLY: "FALSE" } }
 ```
 
 ### `input.list()`
@@ -232,98 +232,98 @@ tv.input.list().then(data => {
 });
 // Example output
 // {
-//     'STATUS': {
-//         'RESULT': 'SUCCESS',
-//         'DETAIL': 'Success'
+//     "STATUS": {
+//         "RESULT": "SUCCESS",
+//         "DETAIL": "Success"
 //     },
-//     'HASHLIST': [
+//     "HASHLIST": [
 //         1234567890,
 //         0987654321,
 //         9999999999
 //     ],
-//     'GROUP': 'G_DEVICES',
-//     'NAME': 'Name Input',
-//     'PARAMETERS': {
-//         'FLAT': 'TRUE',
-//         'HELPTEXT': 'FALSE',
-//         'HASHONLY': 'FALSE'
+//     "GROUP": "G_DEVICES",
+//     "NAME": "Name Input",
+//     "PARAMETERS": {
+//         "FLAT": "TRUE",
+//         "HELPTEXT": "FALSE",
+//         "HASHONLY": "FALSE"
 //     },
-//     'ITEMS': [
+//     "ITEMS": [
 //         {
-//         'HASHVAL': 1111111111,
-//         'CNAME': 'cast',
-//         'NAME': 'CAST',
-//         'TYPE': 'T_DEVICE_V1',
-//         'READONLY': 'TRUE',
-//         'VALUE': {
-//             'NAME': 'CAST',
-//             'METADATA': ''
+//         "HASHVAL": 1111111111,
+//         "CNAME": "cast",
+//         "NAME": "CAST",
+//         "TYPE": "T_DEVICE_V1",
+//         "READONLY": "TRUE",
+//         "VALUE": {
+//             "NAME": "CAST",
+//             "METADATA": ""
 //         }
 //         },
 //         {
-//         'HASHVAL': 2222222222,
-//         'CNAME': 'hdmi1',
-//         'TYPE': 'T_DEVICE_V1',
-//         'NAME': 'HDMI-1',
-//         'VALUE': {
-//             'NAME': 'BLU-RAY',
-//             'METADATA': ''
+//         "HASHVAL": 2222222222,
+//         "CNAME": "hdmi1",
+//         "TYPE": "T_DEVICE_V1",
+//         "NAME": "HDMI-1",
+//         "VALUE": {
+//             "NAME": "BLU-RAY",
+//             "METADATA": ""
 //         }
 //         },
 //         {
-//         'HASHVAL': 3333333333,
-//         'CNAME': 'hdmi2',
-//         'TYPE': 'T_DEVICE_V1',
-//         'NAME': 'HDMI-2',
-//         'VALUE': {
-//             'NAME': 'XBOX 360',
-//             'METADATA': ''
+//         "HASHVAL": 3333333333,
+//         "CNAME": "hdmi2",
+//         "TYPE": "T_DEVICE_V1",
+//         "NAME": "HDMI-2",
+//         "VALUE": {
+//             "NAME": "XBOX 360",
+//             "METADATA": ""
 //         }
 //         },
 //         {
-//         'HASHVAL': 4444444444,
-//         'CNAME': 'hdmi3',
-//         'TYPE': 'T_DEVICE_V1',
-//         'NAME': 'HDMI-3',
-//         'VALUE': {
-//             'NAME': 'XBOX ONE',
-//             'METADATA': ''
+//         "HASHVAL": 4444444444,
+//         "CNAME": "hdmi3",
+//         "TYPE": "T_DEVICE_V1",
+//         "NAME": "HDMI-3",
+//         "VALUE": {
+//             "NAME": "XBOX ONE",
+//             "METADATA": ""
 //         }
 //         },
 //         {
-//         'HASHVAL': 5555555555,
-//         'CNAME': 'hdmi4',
-//         'TYPE': 'T_DEVICE_V1',
-//         'NAME': 'HDMI-4',
-//         'VALUE': {
-//             'NAME': 'PLAYSTATION',
-//             'METADATA': ''
+//         "HASHVAL": 5555555555,
+//         "CNAME": "hdmi4",
+//         "TYPE": "T_DEVICE_V1",
+//         "NAME": "HDMI-4",
+//         "VALUE": {
+//             "NAME": "PLAYSTATION",
+//             "METADATA": ""
 //         }
 //         },
 //         {
-//         'HASHVAL': 66666666666,
-//         'CNAME': 'hdmi5',
-//         'TYPE': 'T_DEVICE_V1',
-//         'NAME': 'HDMI-5',
-//         'VALUE': {
-//             'NAME': '',
-//             'METADATA': ''
+//         "HASHVAL": 66666666666,
+//         "CNAME": "hdmi5",
+//         "TYPE": "T_DEVICE_V1",
+//         "NAME": "HDMI-5",
+//         "VALUE": {
+//             "NAME": "",
+//             "METADATA": ""
 //         }
 //         },
 //         {
-//         'HASHVAL': 7777777777,
-//         'CNAME': 'comp',
-//         'TYPE': 'T_DEVICE_V1',
-//         'NAME': 'COMP',
-//         'VALUE': {
-//             'NAME': '',
-//             'METADATA': ''
+//         "HASHVAL": 7777777777,
+//         "CNAME": "comp",
+//         "TYPE": "T_DEVICE_V1",
+//         "NAME": "COMP",
+//         "VALUE": {
+//             "NAME": "",
+//             "METADATA": ""
 //         }
 //         }
 //     ],
-//     'URI': '/menu_native/dynamic/tv_settings/devices/name_input',
-//     'CNAME': 'name_input',
-//     'TYPE': 'T_MENU_V1'
+//     "URI": "/menu_native/dynamic/tv_settings/devices/name_input",
+//     "CNAME": "name_input",
+//     "TYPE": "T_MENU_V1"
 // };
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,7 @@ interface SmartcastSettingsPicture {
     size: SmartcastGet;
     position: SmartcastGet;
     modeEdit: SmartcastGet;
+    mode: SmartcastGetSet;
     color: SmartcastSettingsPictureColor;
     calibrationTests: SmartcastGet;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,13 @@ interface SmartcastControlPower {
     toggle(): Promise<any>;
 }
 
+interface SmartcastTimers {
+    get(): Promise<any>;
+    sleepTimer: SmartcastGetSet;
+    autoPowerOffTimer: SmartcastGetSet;
+    blankScreen: SmartcastGetExecute;
+}
+
 interface SmartcastGet {
     get(): Promise<any>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,7 +72,7 @@ interface SmartcastGetExecute {
 interface SmartcastSettings {
     picture: SmartcastSettingsPicture;
     audio: SmartcastGet;
-    timers: SmartcastGet;
+    timers: SmartcastTimers;
     network: SmartcastGet;
     channels: SmartcastGet;
     closedCaptions: SmartcastGet;

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,16 @@ interface SmartcastGet {
     get(): Promise<any>;
 }
 
+interface SmartcastGetSet {
+    get(): Promise<any>;
+    set(value: string): Promise<any>;
+}
+
+interface SmartcastGetExecute {
+    get(): Promise<any>;
+    execute(): Promise<any>;
+}
+
 interface SmartcastSettings {
     picture: SmartcastSettingsPicture;
     audio: SmartcastGet;

--- a/index.js
+++ b/index.js
@@ -387,6 +387,113 @@ let SMARTCAST = function smartcast(host, authKey) {
         timers: {
             get: () => {
                 return sendRequest('get', host + '/menu_native/dynamic/tv_settings/timers', _authKey);
+            },
+            autoPowerOffTimer: {
+                get: () => {
+                    return sendRequest('get', host + '/menu_native/dynamic/tv_settings/timers/auto_power_off_timer', _authKey);
+                },
+                set: (value) => {
+                    return new Promise((resolve, reject) => {
+                        let powerOffValues = [
+                            { index: 0, value: '10 minutes'}, 
+                            { index: 1, value: 'Off'}
+                        ];
+                        
+                        // Accept any value that matches the integer index or string value
+                        if (!powerOffValues.includes(t => t.value === value || t.index === value)) {
+                            reject('invalid value: ' + value);
+                            return;
+                        }
+                        
+                        // Transform an integer index to its string value
+                        if (typeof value === 'number') {
+                            value = powerOffValues.find(t => t.index === value).value;
+                        }
+
+                        this.settings.timers.autoPowerOffTimer.get().then((response) => {
+                            let autoPowerOffTimer = response.ITEMS.find(i => i.CNAME === 'auto_power_off_timer');
+                            
+                            if (!autoPowerOffTimer) {
+                                reject('could not get auto power off timer settings');
+                                return;
+                            }
+                            
+                            let data = {
+                                'REQUEST': 'MODIFY',
+                                'HASHVAL': autoPowerOffTimer.HASHVAL,
+                                'VALUE': value
+                            };
+                            sendRequest('put', host + '/menu_native/dynamic/tv_settings/timers/auto_power_off_timer', _authKey, data).then(resolve).catch(reject);
+                        }).catch(reject);
+                    });
+                }
+            },
+            sleepTimer: {
+                get: () => {
+                    return sendRequest('get', host + '/menu_native/dynamic/tv_settings/timers/sleep_timer', _authKey);
+                },
+                set: (value) => {
+                    return new Promise((resolve, reject) => {
+                        let timerValues = [
+                            { index: 0, value: 'Off'}, 
+                            { index: 1, value: '30 minutes'}, 
+                            { index: 2, value: '60 minutes'}, 
+                            { index: 3, value: '90 minutes'}, 
+                            { index: 4, value: '120 minutes'}, 
+                            { index: 5, value: '180 minutes'}
+                        ];
+                        
+                        // Accept any value that matches the integer index or string value
+                        if (timerValues.find(t => t.value === value || t.index === value) === undefined) {
+                            reject('invalid value: ' + value);
+                            return;
+                        }
+                        
+                        // Transform an integer index to its string value
+                        if (typeof value === 'number') {
+                            value = timerValues.find(t => t.index === value).value;
+                        }
+
+                        this.settings.timers.sleepTimer.get().then((response) => {
+                            let sleepTimer = response.ITEMS.find(i => i.CNAME === 'sleep_timer');
+                            
+                            if (!sleepTimer) {
+                                reject('could not get picture mode settings');
+                                return;
+                            }
+                            
+                            let data = {
+                                'REQUEST': 'MODIFY',
+                                'HASHVAL': sleepTimer.HASHVAL,
+                                'VALUE': value
+                            };
+                            sendRequest('put', host + '/menu_native/dynamic/tv_settings/timers/sleep_timer', _authKey, data).then(resolve).catch(reject);
+                        }).catch(reject);
+                    });
+                }
+            },
+            blankScreen: {
+                get: () => {
+                    return sendRequest('get', host + '/menu_native/dynamic/tv_settings/timers/blank_screen', _authKey);
+                },
+                execute: () => {
+                    return new Promise((resolve, reject) => {
+                        this.settings.timers.blankScreen.get().then((response) => {
+                            let blankScreen = response.ITEMS.find(x => x.CNAME === "blank_screen");
+                            if (!blankScreen) {
+                                reject('Unable to get blank_screen');
+                                return;
+                            }
+
+                            let data = {
+                                'REQUEST': 'MODIFY',
+                                'HASHVAL': blankScreen.HASHVAL,
+                                'VALUE': 'T_ACTION_V1' // Any string value would suffice
+                            };
+                            sendRequest('put', host + '/menu_native/dynamic/tv_settings/timers/blank_screen', _authKey, data).then(resolve).catch(reject)
+                        }).catch(reject);
+                    });
+                }
             }
         },
         network: {

--- a/index.js
+++ b/index.js
@@ -322,6 +322,40 @@ let SMARTCAST = function smartcast(host, authKey) {
                     return sendRequest('get', host + '/menu_native/dynamic/tv_settings/picture/picture_position', _authKey);
                 }
             },
+            mode: {
+                get: () => {
+                    return sendRequest('get', host + '/menu_native/dynamic/tv_settings/picture/picture_mode', _authKey);
+                },
+                set: (value) => {
+                    return new Promise((resolve, reject) => {
+                        if (typeof value !== 'string') {
+                            reject('value must be a string');
+                            return;
+                        }
+
+                        this.settings.picture.mode.get().then((settings) => {
+                            let pictureMode = settings.ITEMS.find(i => i.CNAME === 'picture_mode');
+                            if (!pictureMode) {
+                                reject('could not get picture mode settings');
+                                return;
+                            }
+
+                            let pictureModeValue = pictureMode.ELEMENTS.find(i => i === value);
+                            if (!pictureModeValue) {
+                                reject('Picture mode: ' + value + ' not found');
+                                return;
+                            }
+                            
+                            let data = {
+                                'REQUEST': 'MODIFY',
+                                'HASHVAL': pictureMode.HASHVAL,
+                                'VALUE': pictureModeValue
+                            };
+                            sendRequest('put', host + '/menu_native/dynamic/tv_settings/picture/picture_mode', _authKey, data).then(resolve).catch(reject);
+                        }).catch(reject);
+                    });
+                }
+            },
             modeEdit: {
                 get: () => {
                     return sendRequest('get', host + '/menu_native/dynamic/tv_settings/picture/picture_mode_edit', _authKey);

--- a/index.js
+++ b/index.js
@@ -342,7 +342,7 @@ let SMARTCAST = function smartcast(host, authKey) {
 
                             let pictureModeValue = pictureMode.ELEMENTS.find(i => i === value);
                             if (!pictureModeValue) {
-                                reject('Picture mode: ' + value + ' not found');
+                                reject('value out of range');
                                 return;
                             }
                             
@@ -400,8 +400,8 @@ let SMARTCAST = function smartcast(host, authKey) {
                         ];
                         
                         // Accept any value that matches the integer index or string value
-                        if (!powerOffValues.includes(t => t.value === value || t.index === value)) {
-                            reject('invalid value: ' + value);
+                        if (powerOffValues.find(t => t.value === value || t.index === value) === undefined) {
+                            reject('value out of range');
                             return;
                         }
                         
@@ -445,7 +445,7 @@ let SMARTCAST = function smartcast(host, authKey) {
                         
                         // Accept any value that matches the integer index or string value
                         if (timerValues.find(t => t.value === value || t.index === value) === undefined) {
-                            reject('invalid value: ' + value);
+                            reject('value out of range');
                             return;
                         }
                         

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ let sendRequest = (method, url, authKey, data) => {
 
     if (authKey) {
         req.headers = {
-            'AUTH': authKey
+            AUTH: authKey
         };
     }
 
@@ -92,8 +92,8 @@ let SMARTCAST = function smartcast(host, authKey) {
             _deviceId = deviceId || 'node-app-' + new Date().getTime();
 
             let data = {
-                "DEVICE_NAME": _deviceName,
-                "DEVICE_ID": _deviceId
+                DEVICE_NAME: _deviceName,
+                DEVICE_ID: _deviceId
             };
             return sendRequest('put', host + '/pairing/start', null, data).then((data) => {
                 if (data && data.STATUS && data.STATUS.RESULT === 'SUCCESS') {
@@ -116,10 +116,10 @@ let SMARTCAST = function smartcast(host, authKey) {
          */
         pair: (pin) => {
             let data = {
-                "DEVICE_ID": _deviceId,
-                "CHALLENGE_TYPE": 1,
-                "RESPONSE_VALUE": pin,
-                "PAIRING_REQ_TOKEN": _pairingRequestToken
+                DEVICE_ID: _deviceId,
+                CHALLENGE_TYPE: 1,
+                RESPONSE_VALUE: pin,
+                PAIRING_REQ_TOKEN: _pairingRequestToken
             };
             return sendRequest('put', host + '/pairing/pair', null, data).then((data) => {
                 if (data && data.STATUS.RESULT === 'SUCCESS') {
@@ -170,9 +170,9 @@ let SMARTCAST = function smartcast(host, authKey) {
                         }
 
                         let data = {
-                            "REQUEST": "MODIFY",
-                            "VALUE": inputName,
-                            "HASHVAL": currentInput.ITEMS[0].HASHVAL
+                            REQUEST: "MODIFY",
+                            VALUE: inputName,
+                            HASHVAL: currentInput.ITEMS[0].HASHVAL
                         };
 
                         sendRequest('put', host + '/menu_native/dynamic/tv_settings/devices/current_input', _authKey, data).then(resolve).catch(reject)
@@ -209,9 +209,9 @@ let SMARTCAST = function smartcast(host, authKey) {
                         }
 
                         let data = {
-                            'REQUEST': 'MODIFY',
-                            'HASHVAL': volume.HASHVAL,
-                            'VALUE': Math.round(value)
+                            REQUEST: 'MODIFY',
+                            HASHVAL: volume.HASHVAL,
+                            VALUE: Math.round(value)
                         };
                         sendRequest('put', host + '/menu_native/dynamic/tv_settings/audio/volume', _authKey, data).then(resolve).catch(reject)
                     }).catch(reject);
@@ -347,9 +347,9 @@ let SMARTCAST = function smartcast(host, authKey) {
                             }
                             
                             let data = {
-                                'REQUEST': 'MODIFY',
-                                'HASHVAL': pictureMode.HASHVAL,
-                                'VALUE': pictureModeValue
+                                REQUEST: 'MODIFY',
+                                HASHVAL: pictureMode.HASHVAL,
+                                VALUE: pictureModeValue
                             };
                             sendRequest('put', host + '/menu_native/dynamic/tv_settings/picture/picture_mode', _authKey, data).then(resolve).catch(reject);
                         }).catch(reject);
@@ -419,9 +419,9 @@ let SMARTCAST = function smartcast(host, authKey) {
                             }
                             
                             let data = {
-                                'REQUEST': 'MODIFY',
-                                'HASHVAL': autoPowerOffTimer.HASHVAL,
-                                'VALUE': value
+                                REQUEST: 'MODIFY',
+                                HASHVAL: autoPowerOffTimer.HASHVAL,
+                                VALUE: value
                             };
                             sendRequest('put', host + '/menu_native/dynamic/tv_settings/timers/auto_power_off_timer', _authKey, data).then(resolve).catch(reject);
                         }).catch(reject);
@@ -463,9 +463,9 @@ let SMARTCAST = function smartcast(host, authKey) {
                             }
                             
                             let data = {
-                                'REQUEST': 'MODIFY',
-                                'HASHVAL': sleepTimer.HASHVAL,
-                                'VALUE': value
+                                REQUEST: 'MODIFY',
+                                HASHVAL: sleepTimer.HASHVAL,
+                                VALUE: value
                             };
                             sendRequest('put', host + '/menu_native/dynamic/tv_settings/timers/sleep_timer', _authKey, data).then(resolve).catch(reject);
                         }).catch(reject);
@@ -486,9 +486,9 @@ let SMARTCAST = function smartcast(host, authKey) {
                             }
 
                             let data = {
-                                'REQUEST': 'MODIFY',
-                                'HASHVAL': blankScreen.HASHVAL,
-                                'VALUE': 'T_ACTION_V1' // Any string value would suffice
+                                REQUEST: 'MODIFY',
+                                HASHVAL: blankScreen.HASHVAL,
+                                VALUE: 'T_ACTION_V1' // Any string value would suffice
                             };
                             sendRequest('put', host + '/menu_native/dynamic/tv_settings/timers/blank_screen', _authKey, data).then(resolve).catch(reject)
                         }).catch(reject);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,733 +4,843 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ajv": {
-      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "requires": {
-        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-      }
-    },
-    "asn1": {
-      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-    },
-    "assertion-error": {
-      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-      "dev": true
-    },
-    "async": {
-      "version": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
-      "requires": {
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-      }
-    },
-    "asynckit": {
-      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-    },
-    "aws4": {
-      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-      }
-    },
-    "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-    },
-    "boom": {
-      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-      }
-    },
-    "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-      }
-    },
-    "browser-stdout": {
-      "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "chai": {
-      "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      },
+      "dependencies": {
+        "assertion-error": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+          "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+          "dev": true
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+          "dev": true
+        }
       }
     },
     "chai-string": {
-      "version": "https://registry.npmjs.org/chai-string/-/chai-string-1.4.0.tgz",
-      "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
       "dev": true
     },
-    "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "combined-stream": {
-      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-      }
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
-    "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-      }
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
-    "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "cryptiles": {
-      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-      }
-    },
-    "dashdash": {
-      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
-    "debug": {
-      "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "requires": {
-        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-      }
-    },
-    "deep-eql": {
-      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "dev": true,
-      "requires": {
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
-      }
-    },
-    "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "diff": {
-      "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-      "dev": true
-    },
-    "ecc-jsbn": {
-      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extsprintf": {
-      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-    },
-    "forever-agent": {
-      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "requires": {
-        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
-      }
-    },
-    "formatio": {
-      "version": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
-      }
-    },
-    "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "getpass": {
-      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
-    "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-      }
-    },
-    "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
-    "growl": {
-      "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-      "dev": true
-    },
-    "har-schema": {
-      "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-    },
-    "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "requires": {
-        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-        "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-      }
-    },
-    "has-flag": {
-      "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-      "dev": true
-    },
-    "hawk": {
-      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-      }
-    },
-    "hoek": {
-      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-    },
-    "http-signature": {
-      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
-      }
-    },
-    "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      }
-    },
-    "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "ip": {
-      "version": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-    },
-    "is-typedarray": {
-      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
-    "isstream": {
-      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jsbn": {
-      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-      }
-    },
-    "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "json3": {
-      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
-    "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsprim": {
-      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-        "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
-    "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash._baseassign": {
-      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash.create": {
-      "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-        "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-      }
-    },
-    "lolex": {
-      "version": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-      "dev": true
-    },
-    "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-    },
-    "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-      }
-    },
-    "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
-      }
-    },
-    "minimist": {
-      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-      }
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "mocha": {
-      "version": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
-        "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-        "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "browser-stdout": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+          "dev": true
+        },
+        "growl": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "json3": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+          "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+          "dev": true
+        },
+        "lodash._baseassign": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+          "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash.keys": "3.1.2"
+          }
+        },
+        "lodash._basecopy": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+          "dev": true
+        },
+        "lodash._basecreate": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+          "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+          "dev": true
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+          "dev": true
+        },
+        "lodash._isiterateecall": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+          "dev": true
+        },
+        "lodash.create": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+          "dev": true,
+          "requires": {
+            "lodash._baseassign": "3.2.0",
+            "lodash._basecreate": "3.0.3",
+            "lodash._isiterateecall": "3.0.9"
+          }
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+          "dev": true
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+          "dev": true
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
     },
-    "ms": {
-      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "native-promise-only": {
-      "version": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
-    },
     "node-ssdp": {
-      "version": "https://registry.npmjs.org/node-ssdp/-/node-ssdp-3.2.1.tgz",
-      "integrity": "sha1-Av5RjmJWtgKaWBm75z2qsngylgY=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-ssdp/-/node-ssdp-3.3.0.tgz",
+      "integrity": "sha512-hFBkfUJytKC2x64jljojAbktG8aOL0C1YuNjCK54ZGBBg2382J3oTuK17T+aFgmy47noKHE5arLnYppo0JjcLw==",
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-        "ip": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz"
+        "async": "2.6.1",
+        "bluebird": "3.5.2",
+        "debug": "3.2.5",
+        "extend": "3.0.2",
+        "ip": "1.1.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+          "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "ip": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
-    "oauth-sign": {
-      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-    },
-    "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      }
-    },
-    "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-to-regexp": {
-      "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
-      "requires": {
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-      }
-    },
-    "performance-now": {
-      "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-    },
-    "punycode": {
-      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-        "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
-      }
-    },
-    "request-promise-core": {
-      "version": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "requires": {
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.20"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+        },
+        "mime-types": {
+          "version": "2.1.20",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+          "requires": {
+            "mime-db": "1.36.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "sshpk": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+          "requires": {
+            "asn1": "0.2.4",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.2",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.2",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2",
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "1.1.29",
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "optional": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "verror": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          }
+        }
       }
     },
     "request-promise-native": {
-      "version": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.4.tgz",
-      "integrity": "sha1-hpiOyO7kCORVefzoO/0Fs635oVU=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
       "requires": {
-        "request-promise-core": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-        "stealthy-require": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
-      }
-    },
-    "safe-buffer": {
-      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
-    },
-    "samsam": {
-      "version": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
-      "dev": true
-    },
-    "sax": {
-      "version": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
-    },
-    "sinon": {
-      "version": "https://registry.npmjs.org/sinon/-/sinon-2.3.6.tgz",
-      "integrity": "sha1-lTeOfg+XapcS6bRZH/WznnPcPd4=",
-      "dev": true,
-      "requires": {
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-        "formatio": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-        "lolex": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-        "native-promise-only": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-        "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-        "text-encoding": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.4.3"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+          "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+          "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "1.1.29",
+            "punycode": "1.4.1"
+          }
+        }
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "sinon": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+      "dev": true,
+      "requires": {
+        "diff": "3.5.0",
+        "formatio": "1.2.0",
+        "lolex": "1.6.0",
+        "native-promise-only": "0.8.1",
+        "path-to-regexp": "1.7.0",
+        "samsam": "1.3.0",
+        "text-encoding": "0.6.4",
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "formatio": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+          "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+          "dev": true,
+          "requires": {
+            "samsam": "1.3.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        },
+        "native-promise-only": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+          "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "samsam": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+          "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+          "dev": true
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+          "dev": true
+        },
         "type-detect": {
-          "version": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
           "dev": true
         }
       }
-    },
-    "sntp": {
-      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-      }
-    },
-    "sshpk": {
-      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
-    "stealthy-require": {
-      "version": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-    },
-    "stringstream": {
-      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-    },
-    "supports-color": {
-      "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "dev": true,
-      "requires": {
-        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-      }
-    },
-    "text-encoding": {
-      "version": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
-    },
-    "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "requires": {
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-      }
-    },
-    "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-      }
-    },
-    "tweetnacl": {
-      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
-    },
-    "type-detect": {
-      "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-      "dev": true
-    },
-    "uuid": {
-      "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
-    },
-    "verror": {
-      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "requires": {
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-      }
-    },
-    "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
     }
   }
 }

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -167,6 +167,61 @@ describe('#smart-cast-settings-tests', () => {
         });
     });
 
+    it('timers autoPowerOffTimer set() should not accept integers outside of 0-1', () => {
+        return tv.settings.timers.autoPowerOffTimer.set(2).then(() => {
+            throw new Error('Promise was unexpectedly resolved');
+        }, (error) => {
+            expect(error).to.contain('value out of range')
+        });
+    });
+
+    it('timers autoPowerOffTimer set() should not accept invalid string values', () => {
+        return tv.settings.timers.autoPowerOffTimer.set("30 minutes").then(() => {
+            throw new Error('Promise was unexpectedly resolved');
+        }, (error) => {
+            expect(error).to.contain('value out of range')
+        });
+    });
+
+    it('timers autoPowerOffTimer set() should call api', () => {
+        mockData = {
+            STATUS: {
+                RESULT: "SUCCESS",
+                DETAIL: "Success"
+            },
+            ITEMS: [
+                {
+                    INDEX: 0,
+                    HASHVAL: 3630612972,
+                    NAME: "Auto Power Off",
+                    VALUE: "10 minutes",
+                    CNAME: "auto_power_off_timer",
+                    TYPE: "T_LIST_V1"
+                }
+            ],
+            HASHLIST: [
+                2557875263,
+                2021181097
+            ],
+            URI: "/menu_native/dynamic/tv_settings/timers/auto_power_off_timer",
+            PARAMETERS: {
+                FLAT: "TRUE",
+                HELPTEXT: "FALSE",
+                HASHONLY: "FALSE"
+            }
+        };
+        let get = sinon.stub(tv.settings.timers.autoPowerOffTimer, 'get').returns(Promise.resolve(mockData));
+        let set = sinon.stub(request, 'put').returns(Promise.resolve(mockData));
+
+        return tv.settings.timers.autoPowerOffTimer.set(1).then(() => {
+            expect(set.called).to.be.true;
+            expect(set.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/auto_power_off_timer');
+    
+            get.restore();
+            set.restore();
+        });
+    });
+
     it('network should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -58,12 +58,10 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('picture mode get() should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.picture.mode.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_mode');
 
@@ -76,7 +74,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.picture.color.calibration.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration');
 
@@ -89,7 +86,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.picture.color.tuner.get().then(() => {    
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration/color_tuner');
 
@@ -102,7 +98,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.picture.calibrationTests.get().then(() => {            
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration/calibration_tests');
 
@@ -115,7 +110,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.audio.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/audio');
 
@@ -128,7 +122,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.timers.get().then(() => {    
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers');
 
@@ -137,12 +130,10 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('timers sleepTimer get() should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.timers.sleepTimer.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/sleep_timer');
 
@@ -150,15 +141,14 @@ describe('#smart-cast-settings-tests', () => {
         });
     });
 
-    it('timers blankScreen should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+    it('timers sleepTimer set() should not accept integers outside of 0-5', () => {
+        return tv.settings.timers.sleepTimer.set(6).then(() => {
+            throw new Error('Promise was unexpectedly resolved');
     it('timers blankScreen get() should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.timers.blankScreen.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/blank_screen');
 
@@ -167,12 +157,9 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('timers autoPowerOffTimer get() should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.timers.autoPowerOffTimer.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/auto_power_off_timer');
 
@@ -185,7 +172,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.network.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/network');
 
@@ -198,7 +184,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.channels.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/channels');
 
@@ -211,7 +196,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.closedCaptions.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/closed_captions');
 
@@ -224,7 +208,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.devices.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/devices');
 
@@ -237,7 +220,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.system.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system');
 
@@ -250,7 +232,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.system.information.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information');
 
@@ -263,7 +244,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.system.information.tv.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/tv_information');
 
@@ -276,7 +256,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.system.information.tuner.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/tuner_information');
 
@@ -289,7 +268,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.system.information.network.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/network_information');
 
@@ -302,7 +280,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.system.information.uli.get().then(() => {     
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/uli_information');
 
@@ -315,7 +292,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.mobileDevices.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/mobile_devices');
 
@@ -328,7 +304,6 @@ describe('#smart-cast-settings-tests', () => {
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         return tv.settings.cast.get().then(() => {
-        
             expect(request.get.called).to.be.true;
             expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/cast');
 

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -240,6 +240,58 @@ describe('#smart-cast-settings-tests', () => {
     it('timers sleepTimer set() should not accept integers outside of 0-5', () => {
         return tv.settings.timers.sleepTimer.set(6).then(() => {
             throw new Error('Promise was unexpectedly resolved');
+        }, (error) => {
+            expect(error).to.contain('value out of range')
+        });
+    });
+
+    it('timers sleepTimer set() should not accept invalid string values', () => {
+        return tv.settings.timers.autoPowerOffTimer.set("15 minutes").then(() => {
+            throw new Error('Promise was unexpectedly resolved');
+        }, (error) => {
+            expect(error).to.contain('value out of range')
+        });
+    });
+
+    it('timers sleepTimer set() should call api', () => {
+        mockData = {
+            STATUS: {
+                RESULT: "SUCCESS",
+                DETAIL: "Success"
+            },
+            ITEMS: [
+                {
+                    INDEX: 0,
+                    HASHVAL: 1763227135,
+                    NAME: "Sleep Timer",
+                    VALUE: "Off",
+                    CNAME: "sleep_timer",
+                    TYPE: "T_LIST_V1"
+                }
+            ],
+            HASHLIST: [
+                2984886335,
+                992438970
+            ],
+            URI: "/menu_native/dynamic/tv_settings/timers/sleep_timer",
+            PARAMETERS: {
+                FLAT: "TRUE",
+                HELPTEXT: "FALSE",
+                HASHONLY: "FALSE"
+            }
+        };
+        let get = sinon.stub(tv.settings.timers.sleepTimer, 'get').returns(Promise.resolve(mockData));
+        let set = sinon.stub(request, 'put').returns(Promise.resolve({}));
+
+        return tv.settings.timers.sleepTimer.set(0).then(() => {
+            expect(set.called).to.be.true;
+            expect(set.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/sleep_timer');
+    
+            get.restore();
+            set.restore();
+        });
+    });
+
     it('timers blankScreen get() should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -137,6 +137,19 @@ describe('#smart-cast-settings-tests', () => {
         request.get.restore();
     });
 
+    it('timers sleepTimer should call api', () => {
+        let tv = new smartcast('0.0.0.0'),
+            mockData = {};
+        sinon.stub(request, 'get').returns(Promise.resolve(mockData));
+
+        tv.settings.timers.sleepTimer.get();
+        
+        expect(request.get.called).to.be.true;
+        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/sleep_timer');
+
+        request.get.restore();
+    });
+
     it('network should call api', () => {
         let tv = new smartcast('0.0.0.0'),
             mockData = {};

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -150,6 +150,19 @@ describe('#smart-cast-settings-tests', () => {
         request.get.restore();
     });
 
+    it('timers blankScreen should call api', () => {
+        let tv = new smartcast('0.0.0.0'),
+            mockData = {};
+        sinon.stub(request, 'get').returns(Promise.resolve(mockData));
+
+        tv.settings.timers.blankScreen.get();
+        
+        expect(request.get.called).to.be.true;
+        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/blank_screen');
+
+        request.get.restore();
+    });
+
     it('network should call api', () => {
         let tv = new smartcast('0.0.0.0'),
             mockData = {};

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -6,10 +6,11 @@ let expect = require('chai').expect,
     smartcast = require('../index');
 
 describe('#smart-cast-settings-tests', () => {
+    let tv = new smartcast('0.0.0.0'),
+    mockData = {};
 
     it('picture should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.picture.get();
@@ -21,8 +22,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('picture size should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.picture.size.get();
@@ -34,8 +34,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('picture position should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.picture.position.get();
@@ -47,8 +46,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('picture modeEdit should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.picture.modeEdit.get();
@@ -73,8 +71,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('picture color calibration should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.picture.color.calibration.get();
@@ -86,8 +83,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('picture color tuner should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.picture.color.tuner.get();
@@ -99,8 +95,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('picture calibrationTests should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.picture.calibrationTests.get();
@@ -112,8 +107,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('audio should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.audio.get();
@@ -125,8 +119,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('timers should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.timers.get();
@@ -177,8 +170,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('network should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.network.get();
@@ -190,8 +182,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('channels should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.channels.get();
@@ -203,8 +194,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('closedCaptions should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.closedCaptions.get();
@@ -216,8 +206,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('devices should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.devices.get();
@@ -229,8 +218,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('system should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.system.get();
@@ -242,8 +230,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('system information should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.system.information.get();
@@ -255,8 +242,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('system information tv should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.system.information.tv.get();
@@ -268,8 +254,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('system information tuner should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.system.information.tuner.get();
@@ -281,8 +266,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('system information network should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.system.information.network.get();
@@ -294,8 +278,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('system information uli should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.system.information.uli.get();
@@ -307,8 +290,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('mobileDevices should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.mobileDevices.get();
@@ -320,8 +302,7 @@ describe('#smart-cast-settings-tests', () => {
     });
 
     it('cast should call api', () => {
-        let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
         tv.settings.cast.get();

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -69,6 +69,102 @@ describe('#smart-cast-settings-tests', () => {
         });
     });
 
+    it('picture mode set() should not accept non-string values', () => {
+        return tv.settings.picture.mode.set(0).then(() => {
+            throw new Error('Promise was unexpectedly resolved');
+        }, (error) => {
+            expect(error).to.contain('value must be a string')
+        });
+    });
+
+    it('picture mode set() should not accept invalid string values', () => {
+        mockData = {
+            STATUS: {
+                RESULT: "SUCCESS",
+                DETAIL: "Success"
+            },
+            ITEMS: [
+                {
+                    HASHVAL: 3817665489,
+                    ELEMENTS: [
+                        "Standard",
+                        "Calibrated",
+                        "Vivid",
+                        "Game",
+                        "Computer"
+                    ],
+                    NAME: "Picture Mode",
+                    VALUE: "Calibrated*",
+                    CNAME: "picture_mode",
+                    TYPE: "T_LIST_X_V1"
+                }
+            ],
+            HASHLIST: [
+                3871651898,
+                992438970
+            ],
+            URI: "/menu_native/dynamic/tv_settings/picture/picture_mode",
+            PARAMETERS: {
+                FLAT: "TRUE",
+                HELPTEXT: "FALSE",
+                HASHONLY: "FALSE"
+            }
+        };
+        let get = sinon.stub(tv.settings.picture.mode, 'get').returns(Promise.resolve(mockData));
+        return tv.settings.picture.mode.set("Non-existent picture mode").then(() => {
+            throw new Error('Promise was unexpectedly resolved');
+        }, (error) => {
+            expect(error).to.contain('value out of range')
+            get.restore();
+        });
+    });
+
+    it('picture mode set() should call api', () => {
+        mockData = {
+            STATUS: {
+                RESULT: "SUCCESS",
+                DETAIL: "Success"
+            },
+            ITEMS: [
+                {
+                    HASHVAL: 3817665489,
+                    ELEMENTS: [
+                        "Standard",
+                        "Calibrated",
+                        "Vivid",
+                        "Game",
+                        "Computer"
+                    ],
+                    NAME: "Picture Mode",
+                    VALUE: "Calibrated*",
+                    CNAME: "picture_mode",
+                    TYPE: "T_LIST_X_V1"
+                }
+            ],
+            HASHLIST: [
+                3871651898,
+                992438970
+            ],
+            URI: "/menu_native/dynamic/tv_settings/picture/picture_mode",
+            PARAMETERS: {
+                FLAT: "TRUE",
+                HELPTEXT: "FALSE",
+                HASHONLY: "FALSE"
+            }
+        };
+        let get = sinon.stub(tv.settings.picture.mode, 'get').returns(Promise.resolve(mockData));
+        let set = sinon.stub(request, 'put').returns(Promise.resolve({}));
+
+        return tv.settings.picture.mode.set('Standard').then(() => {
+            expect(set.called).to.be.true;
+            expect(set.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_mode');
+    
+            get.restore();
+            set.restore();
+        });
+    });
+
+
     it('picture color calibration should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -59,6 +59,19 @@ describe('#smart-cast-settings-tests', () => {
         request.get.restore();
     });
 
+    it('picture mode should call api', () => {
+        let tv = new smartcast('0.0.0.0'),
+            mockData = {};
+        sinon.stub(request, 'get').returns(Promise.resolve(mockData));
+
+        tv.settings.picture.mode.get();
+        
+        expect(request.get.called).to.be.true;
+        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_mode');
+
+        request.get.restore();
+    });
+
     it('picture color calibration should call api', () => {
         let tv = new smartcast('0.0.0.0'),
             mockData = {};

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -37,280 +37,303 @@ describe('#smart-cast-settings-tests', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.picture.position.get();
-        
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_position');
-
-        request.get.restore();
+        return tv.settings.picture.position.get().then(() => {
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_position');
+    
+            request.get.restore();
+        });
     });
 
     it('picture modeEdit should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.picture.modeEdit.get();
-        
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_mode_edit');
+        return tv.settings.picture.modeEdit.get().then(() => {
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_mode_edit');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
-    it('picture mode should call api', () => {
+    it('picture mode get() should call api', () => {
         let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.picture.mode.get();
+        return tv.settings.picture.mode.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_mode');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/picture_mode');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('picture color calibration should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.picture.color.calibration.get();
+        return tv.settings.picture.color.calibration.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('picture color tuner should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.picture.color.tuner.get();
+        return tv.settings.picture.color.tuner.get().then(() => {    
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration/color_tuner');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration/color_tuner');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('picture calibrationTests should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.picture.calibrationTests.get();
+        return tv.settings.picture.calibrationTests.get().then(() => {            
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration/calibration_tests');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/picture/color_calibration/calibration_tests');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('audio should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.audio.get();
+        return tv.settings.audio.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/audio');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/audio');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('timers should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.timers.get();
+        return tv.settings.timers.get().then(() => {    
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
-    it('timers sleepTimer should call api', () => {
+    it('timers sleepTimer get() should call api', () => {
         let tv = new smartcast('0.0.0.0'),
-            mockData = {};
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.timers.sleepTimer.get();
+        return tv.settings.timers.sleepTimer.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/sleep_timer');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/sleep_timer');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('timers blankScreen should call api', () => {
         let tv = new smartcast('0.0.0.0'),
             mockData = {};
+    it('timers blankScreen get() should call api', () => {
+        mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.timers.blankScreen.get();
+        return tv.settings.timers.blankScreen.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/blank_screen');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/blank_screen');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
-    it('timers autoPowerOffTimer should call api', () => {
+    it('timers autoPowerOffTimer get() should call api', () => {
         let tv = new smartcast('0.0.0.0'),
             mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.timers.autoPowerOffTimer.get();
+        return tv.settings.timers.autoPowerOffTimer.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/auto_power_off_timer');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/auto_power_off_timer');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('network should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.network.get();
+        return tv.settings.network.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/network');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/network');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('channels should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.channels.get();
+        return tv.settings.channels.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/channels');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/channels');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('closedCaptions should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.closedCaptions.get();
+        return tv.settings.closedCaptions.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/closed_captions');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/closed_captions');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('devices should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.devices.get();
+        return tv.settings.devices.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/devices');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/devices');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('system should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.system.get();
+        return tv.settings.system.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('system information should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.system.information.get();
+        return tv.settings.system.information.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('system information tv should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.system.information.tv.get();
+        return tv.settings.system.information.tv.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/tv_information');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/tv_information');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('system information tuner should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.system.information.tuner.get();
+        return tv.settings.system.information.tuner.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/tuner_information');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/tuner_information');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('system information network should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.system.information.network.get();
+        return tv.settings.system.information.network.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/network_information');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/network_information');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('system information uli should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.system.information.uli.get();
+        return tv.settings.system.information.uli.get().then(() => {     
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/uli_information');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/system/system_information/uli_information');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('mobileDevices should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.mobileDevices.get();
+        return tv.settings.mobileDevices.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/mobile_devices');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/mobile_devices');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
 
     it('cast should call api', () => {
         mockData = {};
         sinon.stub(request, 'get').returns(Promise.resolve(mockData));
 
-        tv.settings.cast.get();
+        return tv.settings.cast.get().then(() => {
         
-        expect(request.get.called).to.be.true;
-        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/cast');
+            expect(request.get.called).to.be.true;
+            expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/cast');
 
-        request.get.restore();
+            request.get.restore();
+        });
     });
     
 });

--- a/test/test-settings.js
+++ b/test/test-settings.js
@@ -163,6 +163,19 @@ describe('#smart-cast-settings-tests', () => {
         request.get.restore();
     });
 
+    it('timers autoPowerOffTimer should call api', () => {
+        let tv = new smartcast('0.0.0.0'),
+            mockData = {};
+        sinon.stub(request, 'get').returns(Promise.resolve(mockData));
+
+        tv.settings.timers.autoPowerOffTimer.get();
+        
+        expect(request.get.called).to.be.true;
+        expect(request.get.firstCall.args[0].url).to.equal('https://0.0.0.0:7345/menu_native/dynamic/tv_settings/timers/auto_power_off_timer');
+
+        request.get.restore();
+    });
+
     it('network should call api', () => {
         let tv = new smartcast('0.0.0.0'),
             mockData = {};


### PR DESCRIPTION
# Overview 
If merged, this would close issue #12.

- [x] README.md updated
- [x] Unit test coverage (87/87 passing)

## Added mechanics
- [x] Interfaces
    - [x] `SmartcastGetSet` (includes `get()` `set()`)
    - [x] `SmartcastGetExecute` (includes `get()`, `execute()`)

## Added features
- [x] Picture mode
    - [x] `tv.settings.picture.mode.get()`
    - [x] `tv.settings.picture.mode.set("Standard")`
- [x] Timers
    - [x] Sleep timer
        - [x] `tv.settings.timers.sleepTimer.get()` 
        - [x] `tv.settings.timers.sleepTimer.set(0)` (0: off, 1: 30 mins, 2: 60 mins ... 5: 180 mins)
        - [x] `tv.settings.timers.sleepTimer.set("Off")` (off)
        - [x] `tv.settings.timers.sleepTimer.set("30 minutes")` (30 mins)
    - [x] Auto power-off timer
        - [x] `tv.settings.timers.autoPowerOffTimer.get()`
        - [x] `tv.settings.timers.autoPowerOffTimer.set(0)` (0: 10 minutes, 1: Off)
        - [x] `tv.settings.timers.autoPowerOffTimer.set("Off")` (off)
        - [x] `tv.settings.timers.autoPowerOffTimer.set("10 minutes")` (10 mins)
    - [x] Blank screen
        - [x] `tv.settings.timers.blankScreen.get()` (response doesn't show if blanked or not, but hashval is useful)
        - [x] `tv.settings.timers.blankScreen.execute()` (blanks screen, must hit d-pad to awaken)

I've taken some liberties here and there so please let me know if I need to conform to any existing contribution guidelines. 