### PR TITLE
patch index.js for older Vizio models

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ let request = require('request-promise-native'),
 let sendRequest = (method, url, authKey, data) => {
     let req = {
         url: url,
+        strictSSL: false,
+        secureProtocol: 'TLSv1_method',
         json: true,
         rejectUnauthorized: false,
         body: data


### PR DESCRIPTION
Switches protocol from default (TLSv2) to TLSv1. This fixed an issue with my E55-D0 running software version 2.0.17/cast version 1.22.78594 where Homebridge was throwing the following error:
RequestError: Error: write EPROTO 140736109753216:error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol:../deps/openssl/openssl/ssl/statem/statem_lib.c:1994

 This would probably be better implemented as a fallback if requests to the TV are throwing the "unsupported protocol" error in order to avoid potentially breaking compatibility with newer TVs. But I am not very familiar with js, so this was my bootstrap solution.